### PR TITLE
Fix search with mjoin columns.

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1583,7 +1583,7 @@ export default class Editor extends NestedData {
 		if ( http.search.value ) {
 			query.where( (q) => {
 				for ( let i = 0, ien = http.columns.length; i < ien; i++ ) {
-					if ( http.columns[i].searchable ) {
+					if ( http.columns[i].searchable === 'true' ) {
 						let field = this._sspField( http, i );
 
 						if ( field ) {
@@ -1599,7 +1599,7 @@ export default class Editor extends NestedData {
 			let column = http.columns[i];
 			let search = column.search.value;
 
-			if ( search !== '' && column.searchable ) {
+			if ( search !== '' && column.searchable === 'true' ) {
 				query.where(
 					this._sspField( http, i ),
 					'LIKE',


### PR DESCRIPTION
The test for true is incorrect, as a string is sent from the client. Rather test for "true" as a string. At the moment any string would be true. This breaks the search for mjoin columns which are not searchable.