### PR TITLE
orderBy allow sorting and multiple fields

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -265,17 +265,16 @@ export default class Options {
 			// of fields to display, we need to add the ordering field, due to the
 			// select distinct.
 			this._order.split(',').forEach((val) => {
-				let field = val.toLocaleLowerCase()
-					.replace(' asc', '')
-					.replace('desc', '')
-					.trim();
+				val = val.toLocaleLowerCase();
+				const direction = val.match(/( desc$| asc$)/g);
+				const field = val.replace(/( desc$| asc$)/, '').trim();
 
 				if (! fields.includes(field)) {
 					q.select(field);
 				}
-			});
 
-			q.orderBy(this._order);
+				q.orderBy(field, direction ? direction[0].trim() : 'asc');
+			});
 		}
 
 		if (this._limit) {


### PR DESCRIPTION
The `order` function did not work with multiple comma separated field names and sorting direction was ignored. 

Following is now possible: 

```javascript
.options('name desc, lastname') # name desc and lastname asc 
.options('name') # will sort asc
.options('name, lastname') # both will be sorted asc
.options('name desc, lastname desc') # both will be sorted desc
```

Included safety regrex to only extract order direction if it is at the end of the string (the current code does  manipulate field names which include asc or desc (eg. decreasing_number = reasing_number)). 

`knex.orderBy` is now inside the loop and optionally adds the direction. One could also generate an array but chaining multiple orderBy does also seem to work just fine. https://knexjs.org/#Builder-orderBy

Cheers
Hannes